### PR TITLE
Use Proper Serialization Lengths

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -157,7 +157,7 @@ type SecretKey struct {
 
 // Serialize --
 func (sec *SecretKey) Serialize() []byte {
-	buf := make([]byte, 2048)
+	buf := make([]byte, 32)
 	// #nosec
 	n := C.blsSecretKeySerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &sec.v)
 	if n == 0 {
@@ -354,7 +354,7 @@ func (keys PublicKeys) JSON() string {
 
 // Serialize --
 func (pub *PublicKey) Serialize() []byte {
-	buf := make([]byte, 2048)
+	buf := make([]byte, 48)
 	// #nosec
 	n := C.blsPublicKeySerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &pub.v)
 	if n == 0 {
@@ -452,7 +452,7 @@ type Sign struct {
 
 // Serialize --
 func (sig *Sign) Serialize() []byte {
-	buf := make([]byte, 2048)
+	buf := make([]byte, 96)
 	// #nosec
 	n := C.blsSignatureSerialize(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &sig.v)
 	if n == 0 {
@@ -692,7 +692,7 @@ func (sig *Sign) VerifyHashWithDomain(pub *PublicKey, hashWithDomain []byte) boo
 
 // SerializeUncompressed --
 func (pub *PublicKey) SerializeUncompressed() []byte {
-	buf := make([]byte, 2048)
+	buf := make([]byte, 96)
 	// #nosec
 	n := C.blsPublicKeySerializeUncompressed(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &pub.v)
 	if n == 0 {
@@ -703,7 +703,7 @@ func (pub *PublicKey) SerializeUncompressed() []byte {
 
 // SerializeUncompressed --
 func (sig *Sign) SerializeUncompressed() []byte {
-	buf := make([]byte, 2048)
+	buf := make([]byte, 192)
 	// #nosec
 	n := C.blsSignatureSerializeUncompressed(unsafe.Pointer(&buf[0]), C.mclSize(len(buf)), &sig.v)
 	if n == 0 {


### PR DESCRIPTION
Instead of defaulting to 2048 for each slice, we instead use the expected slice size for each data type.
Ex:
Secret Key -> 32 bytes
Public Key -> 48 bytes
Signature -> 96 bytes
Uncompressed Signature -> 192 bytes
Uncompressed Public Key -> 96 bytes