### PR TITLE
Check for Error

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -750,8 +750,11 @@ func (sig *Sign) VerifyAggregateHashWithDomain(pubVec []PublicKey, hashWithDomai
 
 // SetETHmode --
 // 0 ; old version, 1 ; latest(eth2.0-spec phase0)
-func SetETHmode(mode int) {
-	C.blsSetETHmode(C.int(mode))
+func SetETHmode(mode int) error {
+	if err := C.blsSetETHmode(C.int(mode)); err != 0 {
+		return fmt.Errorf("got non-zero response code: %d", err)
+	}
+	return nil
 }
 
 // SignatureVerifyOrder --

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -339,7 +339,9 @@ func blsAggregateVerifyNoCheckTest(t *testing.T) {
 }
 
 func testEth(t *testing.T) {
-	SetETHmode(1)
+	if err := SetETHmode(1); err != nil {
+		t.Fatal(err)
+	}
 	ethAggregateTest(t)
 	ethSignTest(t)
 	ethAggregateVerifyNoCheckTest(t)


### PR DESCRIPTION
- [x] Checks for error when setting eth mode, if there is a failure in setting it the 
error returned to the calling function.