### PR TITLE
Go mod file, for dependency and go version management

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module github.com/herumi/bls-eth-go-binary
+
+go 1.12
+


### PR DESCRIPTION
This introduces a `go.mod`, it is pretty standard to have, and useful for others to link local forks of the go module.

The module specifies support Go 1.12, since others may not be on Go 1.13 or 1.14 yet.
