### PR TITLE
AreAllMsgDifferent: Use [32]byte instead of string for less memory allocation

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -809,12 +809,14 @@ func SetETHmode(mode int) error {
 	return nil
 }
 
-func AreAllMsgDifferent(msgVec []byte, msgSize int) bool {
-	n := len(msgVec) / msgSize
-	// How can I use []byte instead of string?
-	set := map[string]struct{}{}
+// AreAllMsgDifferent checks the given message slice to ensure that each 32 byte segment is unique.
+func AreAllMsgDifferent(msgVec []byte) bool {
+	const MSG_SIZE = 32
+	n := len(msgVec) / MSG_SIZE
+	set := make(map[[MSG_SIZE]byte]struct{}, MSG_SIZE)
+	msg := [MSG_SIZE]byte{}
 	for i := 0; i < n; i++ {
-		msg := string(msgVec[i*msgSize : (i+1)*msgSize])
+		copy(msg[:], msgVec[i*MSG_SIZE : (i+1)*MSG_SIZE])
 		_, ok := set[msg]
 		if ok {
 			return false
@@ -830,7 +832,7 @@ func (sig *Sign) innerAggregateVerify(pubVec []PublicKey, msgVec []byte, checkMe
 	if n == 0 || len(msgVec) != MSG_SIZE*n {
 		return false
 	}
-	if checkMessage && !AreAllMsgDifferent(msgVec, MSG_SIZE) {
+	if checkMessage && !AreAllMsgDifferent(msgVec) {
 		return false
 	}
 	return C.blsAggregateVerifyNoCheck(&sig.v, &pubVec[0].v, unsafe.Pointer(&msgVec[0]), MSG_SIZE, C.mclSize(n)) == 1


### PR DESCRIPTION
Key changes:
- Added godoc to AreAllMsgDifferent
- Changed signature of AreAllMsgDifferent to only use 32 byte message sizes
- Changed the set to use [32]byte instead of string

I wrote a quick benchmark to test this
```
goos: linux
goarch: amd64
BenchmarkString-8           3574            343511 ns/op          269024 B/op       3074 allocs/op
BenchmarkByte32-8           5408            203741 ns/op          165675 B/op         38 allocs/op
PASS
```
https://gist.github.com/prestonvanloon/0e4645135a43c155b908939ec1428536