### PR TITLE
add openbsd support to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ ifeq ($(OS),mac)
 	$(eval _OS=darwin)
 	$(eval MIN_CFLAGS=$(MIN_CFLAGS) -fPIC)
 endif
+ifeq ($(OS),openbsd)
+	$(eval _OS=openbsd)
+	$(eval MIN_CFLAGS=$(MIN_CFLAGS) -fPIC)
+endif
 endif
 ifeq ($(CPU),aarch64)
 	$(eval _ARCH=arm64)


### PR DESCRIPTION
This PR adds OpenBSD support to your Makefile. With this change, the instructions in your README on building the static library works on this platform - with the slight difference that the GNU make utility is named gmake on OpenBSD. 

Please also see https://github.com/herumi/mcl/pull/83 for the other part of this request.