### PR TITLE
Automated deploy binaries(linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)

### DIFF
--- a/.github/actions/download-binary-action/action.yml
+++ b/.github/actions/download-binary-action/action.yml
@@ -1,0 +1,20 @@
+name: "download binary"
+description: "download binary wrapper"
+
+inputs:
+  os:
+    description: "os"
+    required: true
+  arch:
+    description: "architecture"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: ${{inputs.os}}-${{inputs.arch}}-libbls384_256.a
+    - name: mv binary
+      shell: bash
+      run: mv libbls384_256.a  bls/lib/${{inputs.os}}/${{inputs.arch}}/libbls384_256.a

--- a/.github/actions/upload-binary-action/action.yml
+++ b/.github/actions/upload-binary-action/action.yml
@@ -1,0 +1,18 @@
+name: "upload binary"
+description: "upload binary wrapper"
+
+inputs:
+  os:
+    description: "os"
+    required: true
+  arch:
+    description: "architecture"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{inputs.os}}-${{inputs.arch}}-libbls384_256.a
+        path: bls/lib/${{inputs.os}}/${{inputs.arch}}/libbls384_256.a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,23 @@ jobs:
         make
         go test -v ./bls
 
+  build-arm64:
+    name: build arm64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11]
+    steps:
+      - uses: actions/checkout@v2
+      - run: git submodule update --init --recursive
+      - name: build on linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install -y make clang libstdc++-8-dev-arm64-cross
+          make clean
+          make CXX=clang++ COMPILE_TARGET=linux-arm64
+      - name: build on mac
+        if: runner.os == 'macOS'
+        run: |
+          make clean
+          make CXX=clang++ COMPILE_TARGET=mac-m1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+# Commit the binaries under `bls/lib/`.
+# - If a pull request is made with release_os in the branch name, it will be committed to that branch.
+# - If there are no differences in the binaries, they will not be committed.
+# - Windows binaries are not yet supported.
+
+name: Release
+on:
+  pull_request:
+
+jobs:
+  archive-binaries:
+    name: archive binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11]
+
+    # Release will only branch that contain release_os.
+    if: "contains(github.head_ref, 'release_os')"
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: go test -v ./bls
+      - run: git submodule update --init --recursive
+      - name: "[linux/amd64] build"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install nasm
+          make clean
+          make CXX=clang++
+          go test -v ./bls
+      - name: "[linux/arm64] build"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install -y make clang libstdc++-8-dev-arm64-cross
+          make clean
+          make CXX=clang++ COMPILE_TARGET=linux-arm64
+      - name: "[linux/amd64] upload binary"
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/upload-binary-action
+        with:
+          os: linux
+          arch: amd64
+      - name: "[linux/arm64] upload binary"
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/upload-binary-action
+        with:
+          os: linux
+          arch: arm64
+      - name: "[darwin/amd64] build"
+        if: runner.os == 'macOS'
+        run: |
+          brew install nasm
+          make clean
+          make
+          go test -v ./bls
+      - name: "[darwin/arm64] build"
+        if: runner.os == 'macOS'
+        run: |
+          make clean
+          make CXX=clang++ COMPILE_TARGET=mac-m1
+      - name: "[darwin/amd64] upload binary"
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/upload-binary-action
+        with:
+          os: darwin
+          arch: amd64
+      - name: "[darwin/arm64] upload binary"
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/upload-binary-action
+        with:
+          os: darwin
+          arch: arm64
+
+  commit-binaries:
+    name: commit binaries
+    runs-on: ubuntu-latest
+    needs: archive-binaries
+    env:
+      BRANCH_NAME: ${{github.head_ref}}  # The branch name to merge
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+      - name: "[linux/amd64] download binary"
+        uses: ./.github/actions/download-binary-action
+        with:
+          os: linux
+          arch: amd64
+      - name: "[linux/arm64] download binary"
+        uses: ./.github/actions/download-binary-action
+        with:
+          os: linux
+          arch: arm64
+      - name: "[darwin/amd64] download binary"
+        uses: ./.github/actions/download-binary-action
+        with:
+          os: darwin
+          arch: amd64
+      - name: "[darwin/arm64] download binary"
+        uses: ./.github/actions/download-binary-action
+        with:
+          os: darwin
+          arch: arm64
+      - name: commit binaries
+        run: |
+          # check change binaries
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No change binaries"
+            exit 0
+          fi
+
+          # commit binaries
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add bls/lib/*
+          git commit -m "[skip ci] add binaries(linux/amd64, linux/arm64, darwin/amd64, darwin/arm64)"
+          git push origin HEAD

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,20 @@ ifeq ($(CPU),systemz)
   _ARCH=s390x
 endif
 
+ifeq ($(COMPILE_TARGET), mac-m1)
+  _OS=darwin
+  _ARCH=arm64
+  _COMPILE_TARGET=-target arm64-apple-macos11
+  OBJS=$(OBJ_DIR)/bls_c384_256.o $(OBJ_DIR)/fp.o $(OBJ_DIR)/base$(BIT).o
+endif
+
+ifeq ($(COMPILE_TARGET), linux-arm64)
+  _OS=linux
+  _ARCH=arm64
+  _COMPILE_TARGET=-target aarch64-linux-gnu --sysroot=/usr/aarch64-linux-gnu
+  OBJS=$(OBJ_DIR)/bls_c384_256.o $(OBJ_DIR)/fp.o $(OBJ_DIR)/base$(BIT).o
+endif
+
 LIB_DIR=bls/lib/$(_OS)/$(_ARCH)
 
 all: $(LIB_DIR)/libbls384_256.a
@@ -57,11 +71,11 @@ $(LIB_DIR)/libbls384_256.a: $(OBJS)
 	$(AR) $(LIB_DIR)/libbls384_256.a $(OBJS)
 
 $(OBJ_DIR)/fp.o:
-	$(CXX) -c -o $(OBJ_DIR)/fp.o $(MCL_DIR)/src/fp.cpp $(MIN_CFLAGS)
+	$(CXX) $(_COMPILE_TARGET) -c -o $(OBJ_DIR)/fp.o $(MCL_DIR)/src/fp.cpp $(MIN_CFLAGS)
 $(OBJ_DIR)/base$(BIT).o: $(MCL_DIR)/src/base$(BIT).ll
-	$(CXX) -c -o $(OBJ_DIR)/base$(BIT).o $(MCL_DIR)/src/base$(BIT).ll $(MIN_CFLAGS)
+	$(CXX) $(_COMPILE_TARGET) -c -o $(OBJ_DIR)/base$(BIT).o $(MCL_DIR)/src/base$(BIT).ll $(MIN_CFLAGS)
 $(OBJ_DIR)/bls_c384_256.o:
-	$(CXX) -c -o $(OBJ_DIR)/bls_c384_256.o $(BLS_DIR)/src/bls_c384_256.cpp $(MIN_CFLAGS)
+	$(CXX) $(_COMPILE_TARGET) -c -o $(OBJ_DIR)/bls_c384_256.o $(BLS_DIR)/src/bls_c384_256.cpp $(MIN_CFLAGS)
 $(MCL_DIR)/obj/static_code.o:
 	$(MAKE) -C $(MCL_DIR) obj/static_code.o
 


### PR DESCRIPTION
This pull request automates the deployment of binaries under `bls/lib/` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64.

- If a pull request is made with `release_os` in the branch name, it will be committed to that branch.
- If there are no differences in the binaries, they will not be committed.
- Windows binaries are not yet supported.
- In this workflow, we also compile arm64 with github actions. But, tests for arm64 are not currently running in CI.
  - If you do not want to auto-add arm64 binaries, please modify the Makefile and remove the arm64 entry from .github/workflows/release.yml.

example: https://github.com/korosuke613/bls-eth-go-binary/pull/3

