### PR TITLE
chore: remove unused min func

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -697,13 +697,6 @@ func (sig *Sign) VerifyHash(pub *PublicKey, hash []byte) bool {
 	return C.blsVerifyHash(&sig.v, &pub.v, getPointer(hash), C.mclSize(len(hash))) == 1
 }
 
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // VerifyAggregateHashes --
 func (sig *Sign) VerifyAggregateHashes(pubVec []PublicKey, hash [][]byte) bool {
 	if pubVec == nil {


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 
